### PR TITLE
[R4R] add kava concurrency test

### DIFF
--- a/integration_test/basic_test.go
+++ b/integration_test/basic_test.go
@@ -101,8 +101,9 @@ func sendCompleteSwap(logger logger, senderExecutor, receiverExecutor common.Exe
 	if cmnErr != nil {
 		return fmt.Errorf("couldn't send htlt tx: %w", cmnErr)
 	}
+	logger.Log("htlt tx hash: ", htltTxHash)
 
-	err = wait(8*time.Second, func() (bool, error) {
+	err = wait(20*time.Second, func() (bool, error) {
 		s := senderExecutor.GetSentTxStatus(htltTxHash)
 		return s == store.TxSentStatusSuccess, nil
 	})

--- a/integration_test/concurrent_test.go
+++ b/integration_test/concurrent_test.go
@@ -54,3 +54,46 @@ func TestConcurrentBnbToKavaSwaps(t *testing.T) {
 		assert.NoErrorf(t, r.err, "swap %d returned error", r.id)
 	}
 }
+
+func TestConcurrentKavaToBnbSwaps(t *testing.T) {
+
+	// 1) setup executors
+
+	config := util.ParseConfigFromFile("deputy/config.json")
+
+	var senderExecutors []common.Executor
+	for i := range kavaUserMnemonics {
+		senderExecutors = append(senderExecutors, setupUserExecutorKava(*config.KavaConfig, kavaUserMnemonics[i]))
+	}
+	senderAddrs := kavaUserAddrs
+
+	var receiverExecutors []common.Executor
+	for i := range bnbUserMnemonics {
+		receiverExecutors = append(receiverExecutors, setupUserExecutorBnb(*config.BnbConfig, bnbUserMnemonics[i]))
+	}
+	receiverAddrs := bnbUserAddrs
+
+	// 2) Send swaps from kava to bnb
+
+	swapAmount := big.NewInt(100_000_000)
+	type result struct {
+		id  int
+		err error
+	}
+	results := make(chan result)
+	for i := range senderExecutors {
+		go func(i int) {
+			t.Logf("sending swap %d\n", i)
+			err := sendCompleteSwap(t, senderExecutors[i], receiverExecutors[i], senderAddrs[i], receiverAddrs[i], swapAmount, kavaDeputyAddr, bnbDeputyAddr, 250)
+			results <- result{i, err}
+		}(i)
+	}
+
+	// 3) Check results
+
+	for range senderExecutors {
+		r := <-results
+		t.Logf("swap %d done, err: %v\n", r.id, r.err)
+		assert.NoErrorf(t, r.err, "swap %d returned error", r.id)
+	}
+}

--- a/integration_test/kava/genesis.json
+++ b/integration_test/kava/genesis.json
@@ -26,7 +26,25 @@
       "send_enabled": true
     },
     "bep3": {
-      "assets_supplies": [],
+      "assets_supplies": [{
+        "current_supply": {
+          "amount": "1000000000000",
+          "denom": "bnb"
+        },
+        "denom": "bnb",
+        "incoming_supply": {
+          "amount": "0",
+          "denom": "bnb"
+        },
+        "outgoing_supply": {
+          "amount": "0",
+          "denom": "bnb"
+        },
+        "supply_limit": {
+          "amount": "4000000000000",
+          "denom": "bnb"
+        }
+      }],
       "atomic_swaps": [],
       "params": {
         "bnb_deputy_address": "kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c",

--- a/integration_test/kava/start-new-chain.sh
+++ b/integration_test/kava/start-new-chain.sh
@@ -48,7 +48,7 @@ printf "$coldWalletMnemonic\n" | kvcli keys add cold-wallet --recover
 for i in {0..5}
 do
     printf "${testUserMnemonics[$i]}\n" | kvcli keys add test-user$i --recover
-    kvd add-genesis-account $(kvcli keys show test-user$i -a) 10000000ukava
+    kvd add-genesis-account $(kvcli keys show test-user$i -a) 10000000ukava,100000000bnb
 done
 
 # Create a delegation tx for the validator and add to genesis

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -53,7 +53,7 @@ func (ob *Observer) fetch(executor common.Executor, startHeight int64) {
 		err := ob.fetchBlock(executor, curBlockLog.Height, nextHeight, curBlockLog.BlockHash)
 		if err != nil {
 			normalizedErr := strings.ToLower(err.Error())
-			if strings.Contains(normalizedErr, "height must be less than or equal to the current blockchain height") ||
+			if strings.Contains(normalizedErr, "must be less than or equal to the current blockchain height") ||
 				strings.Contains(normalizedErr, "not found") {
 				util.Logger.Infof("try to get ahead block, chain=%s, height=%d", executor.GetChain(), nextHeight)
 			} else {


### PR DESCRIPTION
* Adds Kava concurrency test
* Adds `AssetSupplies` and bnb balances to genesis state of kava, so that there is existing outgoing capacity. This makes the kava integration tests independent of binance chain integration tests. 
